### PR TITLE
Read filename from title instead of possibly truncated span element

### DIFF
--- a/src/inject/inject.js
+++ b/src/inject/inject.js
@@ -106,7 +106,7 @@ var GitLabTree = (function () {
             var svgElement = rawFileMetadata.querySelector('svg.diff-file-changed-icon');
             var typeRaw = svgElement.querySelector('use').getAttribute('xlink:href').split('#')[1];
             var hash = rawFileMetadata.querySelector('a').getAttribute('href');
-            var filename = rawFileMetadata.querySelector('.diff-changed-file-path').textContent.trim();
+            var filename = rawFileMetadata.querySelector('.diff-changed-file').getAttribute('title');
             var isCred = svgElement.classList.contains('cred');
             var type = EFileState.UPDATED;
             // Convert type

--- a/src/inject/inject.ts
+++ b/src/inject/inject.ts
@@ -166,7 +166,7 @@ class GitLabTree
 			const svgElement: HTMLElement = rawFileMetadata.querySelector( 'svg.diff-file-changed-icon' ) as HTMLElement;
 			const typeRaw: string = svgElement.querySelector( 'use' ).getAttribute('xlink:href').split('#')[1];
 			const hash: string = rawFileMetadata.querySelector( 'a' ).getAttribute('href');
-			const filename: string = rawFileMetadata.querySelector( '.diff-changed-file-path' ).textContent.trim();
+			const filename: string = rawFileMetadata.querySelector( '.diff-changed-file' ).getAttribute('title');
 			const isCred: boolean = svgElement.classList.contains( 'cred' );
 			
 			let type: EFileState = EFileState.UPDATED;


### PR DESCRIPTION
This is how the source looks for longer filenames:
![screenshot](https://user-images.githubusercontent.com/1013756/36975699-33bd17d6-207b-11e8-8271-614d27ed3fc6.png)

However, I only tested it with our current github installation (v10.5.1).