### PR TITLE
Change position for settings overlay

### DIFF
--- a/src/inject/style.styl
+++ b/src/inject/style.styl
@@ -288,7 +288,7 @@
 
 .gitlab-tree-plugin__settings
 {
-	position: absolute;
+	position: fixed;
     top: 0;
     bottom: 0;
     right: 0;


### PR DESCRIPTION
Hi

It's look a bit strange that settings` overlay have 'position: absolute'. Because menu located at the bottom but settings located on the top.

We should use 'position: fixed' instead.