### PR TITLE
refactor: use localstorage replace chrome storage

### DIFF
--- a/src/inject/main.ts
+++ b/src/inject/main.ts
@@ -9,9 +9,6 @@ import { Settings } from './settings';
 import { PubSub } from './libs/pubsub';
 import { SettingsStore, ISettings } from './settings.store';
 
-declare const chrome, browser;
-
-
 @autoinject
 export class GitLabTree
 {
@@ -28,7 +25,6 @@ export class GitLabTree
 	rightElement: HTMLDivElement = document.createElement( 'div' );
 	
 	lastActive: string = '';
-	storage = (chrome || browser).storage.local
 
 	hashChangeListener: () => void;
 	expandListener: ( e: MouseEvent ) => void;

--- a/src/inject/settings.tsx
+++ b/src/inject/settings.tsx
@@ -12,7 +12,6 @@ export enum EFileSort { AZName, ZAName, AZExt, ZAExt };
 export class Settings
 {
 	state = {} as any;
-	storage = (chrome || browser).storage.local
 
 	constructor( private views: Views, private pubsub: PubSub, private settingsStore: SettingsStore )
 	{


### PR DESCRIPTION
I use this extension by nginx inject js css，so can't use chrome's ability
use the localstorage replace the chrome's storage  

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203513531063861
  - https://app.asana.com/0/0/1203508449701065